### PR TITLE
Rockspec compatible proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ The neovim package specification supports a single, top-level package metadata f
 * `dependencies`
 ** TBD
 
+* `dependency_sources`
+** TBD
+
 # Example
 
 ```lua
@@ -38,8 +41,13 @@ description = {
    license = "Apache-2.0" 
 }
 dependencies = {
-   "neovim >= 0.6.1"
+   "neovim >= 0.6.1",
+   "gitsigns >= 0.4",
 }
+dependency_sources = {
+   neovim = "https://github.com/neovim/neovim.git",
+   gitsigns = "https://github.com/lewis6991/gitsigns.nvim.git"
+} 
 ```
 
 And in json format
@@ -58,7 +66,12 @@ And in json format
     "license" : "Apache-2.0" 
   },
   "dependencies" : {
-     "neovim >: 0.6.1"
+     "neovim >= 0.6.1",
+     "gitsigns >= 0.4"
+  }
+  "dependency_sources" : {
+     "neovim": "https://github.com/neovim/neovim.git",
+     "gitsigns": "https://github.com/lewis6991/gitsigns.nvim.git"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The neovim package specification supports a single, top-level package metadata f
 
 * `package` : String, the name of the package
 
-* `version` : String, the version of the package. Should obey semantic versioning conventions, for example `0.1.0`. For all version identifiers, implementation should check for a `version` prefixed with `v` in the git repository, as this is a common convention.
+* `version` : String, the version of the package. Should obey semantic versioning conventions, for example `0.1.0`. Plugins should have a git commit with a `tag` matching this version. For all version identifiers, implementation should check for a `version` prefixed with `v` in the git repository, as this is a common convention.
 
 * `specification_version` : String, the current specification version. (0.1.0) at this time.
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
-# nvim-package-specification
+# `plugin.json`
+
+The neovim package specification supports a single, top-level package metadata file. This file can be *either* 'plugin.lua' or 'plugin.json'. The file is a superset of the Rockspec File Format and can contain the following fields
+
+* `package` : String, the name of the package
+
+* `version` : String, the version of the package. Should obey semantic versioning conventions and be prefixed with a `v`, for example, `v0.1.0`
+
+* `source` : Table, the source is a table that contains a `url` field, which points to either the git commit of the current version of the package, or the source tarball.
+
+* `description` : Table, the description is a table that includes the following nested fields:
+	* `summary` : String, a short description of the package, typically less than 100 character long.
+	* `detailed` : String, a long-form description of the package, this should convey the package's principal functionality to the user without being as detailed as the package readme.
+	* `homepage` : This is the homepage of the package, which in most cases will be the GitHub URL.
+	* `License` : This is the License type of the package.
+
+* `dependencies`
+** TBD
+
+# Example
+
+```lua
+package = "lspconfig"
+version = "v0.1.2"
+source = {
+   url = "https://github.com/neovim/nvim-lspconfig/archive/refs/tags/v0.1.2.tar.gz"
+}
+description = {
+   summary = "Quickstart configurations for the Nvim-lsp client",
+   detailed = [[
+   	lspconfig is a set of configurations for language servers for use with Neovim's built-in language server client. Lspconfig handles configuring, launching, and attaching language servers.
+   ]],
+   homepage = "https://github.com/neovim/nvim-lspconfig/", 
+   license = "Apache-2.0" 
+}
+dependencies = {
+   "neovim >= 0.6.1"
+}
+```
+
+And in json format
+```json
+{
+  "package" : "lspconfig",
+  "version" : "v0.1.2",
+  "source" : {
+    "url" : "https://github.com/neovim/nvim-lspconfig/archive/refs/tags/v0.1.2.tar.gz"
+  },
+  "description" : {
+    "summary" : "Quickstart configurations for the Nvim-lsp client",
+    "detailed" : "lspconfig is a set of configurations for language servers for use with Neovim's built-in language server client. Lspc onfig handles configuring, launching, and attaching language servers",
+    "homepage" : "https://github.com/neovim/nvim-lspconfig/", 
+    "license" : "Apache-2.0" 
+  },
+  "dependencies" : {
+     "neovim >: 0.6.1"
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ The neovim package specification supports a single, top-level package metadata f
 
 * `specification_version` : String, the current specification version. (0.1.0) at this time.
 
-
-* `source` : Table, the source is a table that contains a `url` field, which points to either the git commit of the current version of the package, or the source tarball.
+* `source` : Table, the source is a table that contains a `url` field, which points to the git repository of the current package.
 
 * `description` : Table, the description is a table that includes the following nested fields:
 	* `summary` : String, a short description of the package, typically less than 100 character long.
@@ -30,7 +29,7 @@ package = "lspconfig"
 version = "0.1.2"
 specification_version = "0.1.0"
 source = {
-   url = "https://github.com/neovim/nvim-lspconfig/archive/refs/tags/v0.1.2.tar.gz"
+  url = "git://github.com/neovim/nvim-lspconfig.git",
 }
 description = {
    summary = "Quickstart configurations for the Nvim-lsp client",
@@ -57,7 +56,8 @@ And in json format
   "version" : "0.1.2",
   "specification_version" : "0.1.0",
   "source" : {
-    "url" : "https://github.com/neovim/nvim-lspconfig/archive/refs/tags/v0.1.2.tar.gz"
+     "url" : "git://github.com/neovim/nvim-lspconfig.git",
+     "tag" : "0.1.2",
   },
   "description" : {
     "summary" : "Quickstart configurations for the Nvim-lsp client",

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ The neovim package specification supports a single, top-level package metadata f
 
 * `package` : String, the name of the package
 
-* `version` : String, the version of the package. Should obey semantic versioning conventions and be prefixed with a `v`, for example, `v0.1.0`
+* `version` : String, the version of the package. Should obey semantic versioning conventions, for example `0.1.0`
 
-* `specification_version` : String, the current specification version. (v0.1.0) at this time.
+* `specification_version` : String, the current specification version. (0.1.0) at this time.
 
 
 * `source` : Table, the source is a table that contains a `url` field, which points to either the git commit of the current version of the package, or the source tarball.
@@ -24,8 +24,8 @@ The neovim package specification supports a single, top-level package metadata f
 
 ```lua
 package = "lspconfig"
-version = "v0.1.2"
-specification_version = "v0.1.0"
+version = "0.1.2"
+specification_version = "0.1.0"
 source = {
    url = "https://github.com/neovim/nvim-lspconfig/archive/refs/tags/v0.1.2.tar.gz"
 }
@@ -46,8 +46,8 @@ And in json format
 ```json
 {
   "package" : "lspconfig",
-  "version" : "v0.1.2",
-  "specification_version" : "v0.1.0",
+  "version" : "0.1.2",
+  "specification_version" : "0.1.0",
   "source" : {
     "url" : "https://github.com/neovim/nvim-lspconfig/archive/refs/tags/v0.1.2.tar.gz"
   },

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The neovim package specification supports a single, top-level package metadata f
 
 * `package` : String, the name of the package
 
-* `version` : String, the version of the package. Should obey semantic versioning conventions, for example `0.1.0`
+* `version` : String, the version of the package. Should obey semantic versioning conventions, for example `0.1.0`. For all version identifiers, implementation should check for a `version` prefixed with `v` in the git repository, as this is a common convention.
 
 * `specification_version` : String, the current specification version. (0.1.0) at this time.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ The neovim package specification supports a single, top-level package metadata f
 
 * `version` : String, the version of the package. Should obey semantic versioning conventions and be prefixed with a `v`, for example, `v0.1.0`
 
+* `specification_version` : String, the current specification version. (v0.1.0) at this time.
+
+
 * `source` : Table, the source is a table that contains a `url` field, which points to either the git commit of the current version of the package, or the source tarball.
 
 * `description` : Table, the description is a table that includes the following nested fields:
@@ -22,6 +25,7 @@ The neovim package specification supports a single, top-level package metadata f
 ```lua
 package = "lspconfig"
 version = "v0.1.2"
+specification_version = "v0.1.0"
 source = {
    url = "https://github.com/neovim/nvim-lspconfig/archive/refs/tags/v0.1.2.tar.gz"
 }
@@ -43,6 +47,7 @@ And in json format
 {
   "package" : "lspconfig",
   "version" : "v0.1.2",
+  "specification_version" : "v0.1.0",
   "source" : {
     "url" : "https://github.com/neovim/nvim-lspconfig/archive/refs/tags/v0.1.2.tar.gz"
   },

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `plugin.json`
+# Plugin metadata specification
 
 The neovim package specification supports a single, top-level package metadata file. This file can be *either* 'plugin.lua' or 'plugin.json'. The file is a superset of the Rockspec File Format and can contain the following fields
 
@@ -15,7 +15,7 @@ The neovim package specification supports a single, top-level package metadata f
 	* `summary` : String, a short description of the package, typically less than 100 character long.
 	* `detailed` : String, a long-form description of the package, this should convey the package's principal functionality to the user without being as detailed as the package readme.
 	* `homepage` : This is the homepage of the package, which in most cases will be the GitHub URL.
-	* `License` : This is [SPDX](https://spdx.org/licenses/) license identifier. Dual licensing is indicated via joining the relevant licenses via `/`.
+	* `license` : This is [SPDX](https://spdx.org/licenses/) license identifier. Dual licensing is indicated via joining the relevant licenses via `/`.
 
 * `dependencies`
 ** TBD

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The neovim package specification supports a single, top-level package metadata f
 	* `summary` : String, a short description of the package, typically less than 100 character long.
 	* `detailed` : String, a long-form description of the package, this should convey the package's principal functionality to the user without being as detailed as the package readme.
 	* `homepage` : This is the homepage of the package, which in most cases will be the GitHub URL.
-	* `License` : This is the License type of the package.
+	* `License` : This is [SPDX](https://spdx.org/licenses/) license identifier. Dual licensing is indicated via joining the relevant licenses via `/`.
 
 * `dependencies`
 ** TBD


### PR DESCRIPTION
The big thing to figure out is "sources", unlike luarocks we can't reference packages by name if we intend for this to be used without a source repository. We could add a nested field "url".